### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   type: "website"
   lifecycle: "production"
-  owner: "tnt"
+  owner: "team_norgeskart_og_topo"
   system: "norgeskart"
 ---
 apiVersion: "backstage.io/v1alpha1"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.